### PR TITLE
fix: lookup secrets from operator namespace

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,5 +1,8 @@
 import Config
 
+config :kompost,
+  operator_namespace: System.get_env("BONNY_POD_NAMESPACE", "kompost")
+
 config :kompost, Kompost.Kompo,
   postgres: System.get_env("KOMPO_POSTGRES_ENABLED", "true") in ["true", "1"],
   temporal: System.get_env("KOMPO_TEMPORAL_ENABLED", "true") in ["true", "1"]

--- a/lib/kompost/kompo/postgres/controller/instance_controller.ex
+++ b/lib/kompost/kompo/postgres/controller/instance_controller.ex
@@ -87,14 +87,15 @@ defmodule Kompost.Kompo.Postgres.Controller.InstanceController do
 
   defp get_connection_args(instance, conn) do
     %{
-      "metadata" => %{"namespace" => namespace},
-      "spec" => %{"passwordSecretRef" => %{"name" => secret_name, "key" => key} = secret_ref}
+      "spec" => %{"passwordSecretRef" => %{"name" => secret_name, "key" => key}}
     } = instance
 
     with {:ok, secret} <-
            K8s.Client.get("v1", "Secret",
              name: secret_name,
-             namespace: secret_ref["namespace"] || namespace
+             namespace:
+               instance["metadata"]["namespace"] ||
+                 Application.fetch_env!(:kompost, :operator_namespace)
            )
            |> K8s.Client.put_conn(conn)
            |> K8s.Client.run() do


### PR DESCRIPTION
Cluster scoped compontents like PostgresClusterInstance can't read secrets from "their" namespace as they are cluster scoped. Therefore the secret must reside in the same namespace as the operator.