### PR TITLE
fix privilege check if no access to pg_authid

### DIFF
--- a/test/kompost/kompo/postgres/controller/instance_controller_integration_test.exs
+++ b/test/kompost/kompo/postgres/controller/instance_controller_integration_test.exs
@@ -150,7 +150,7 @@ defmodule Kompost.Kompo.Postgres.Controller.ClusterInstanceControllerIntegration
   describe "privileges" do
     @tag :integration
     @tag :postgres
-    test "Privileged condition status is true if user is superuser", %{
+    test "Privileged condition status is true if user has privileges", %{
       conn: conn,
       timeout: timeout,
       resource_name: resource_name
@@ -165,11 +165,7 @@ defmodule Kompost.Kompo.Postgres.Controller.ClusterInstanceControllerIntegration
         |> ResourceHelper.instance_with_secret_ref(@namespace)
         |> GlobalResourceHelper.k8s_apply!(conn)
 
-      created_resource =
-        GlobalResourceHelper.wait_until_observed!(created_resource, conn, timeout)
-
-      conditions = Map.new(created_resource["status"]["conditions"], &{&1["type"], &1})
-      assert "True" == conditions["Privileged"]["status"]
+      GlobalResourceHelper.wait_for_condition!(created_resource, conn, "Privileged", timeout)
     end
   end
 end

--- a/test/kompost/kompo/postgres/instance_integration_test.exs
+++ b/test/kompost/kompo/postgres/instance_integration_test.exs
@@ -1,0 +1,92 @@
+defmodule Kompost.Kompo.Postgres.InstanceIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias Kompost.Kompo.Postgres.Instance, as: MUT
+
+  setup_all do
+    {:ok, conn} =
+      Postgrex.start_link(
+        host: System.get_env("POSTGRES_HOST", "127.0.0.1"),
+        port: System.fetch_env!("POSTGRES_EXPOSED_PORT"),
+        username: System.fetch_env!("POSTGRES_USER"),
+        password: System.fetch_env!("POSTGRES_PASSWORD"),
+        host: "127.0.0.1",
+        database: "postgres"
+      )
+
+    Postgrex.query(
+      conn,
+      ~s/CREATE ROLE nocreaterole WITH PASSWORD 'password' CREATEDB NOCREATEROLE NOINHERIT LOGIN/,
+      []
+    )
+
+    Postgrex.query(
+      conn,
+      ~s/CREATE ROLE nocreatedb WITH PASSWORD 'password' NOCREATEDB CREATEROLE NOINHERIT LOGIN/,
+      []
+    )
+
+    on_exit(fn ->
+      Postgrex.query!(conn, ~s/DROP ROLE IF EXISTS nocreatedb/, [])
+      Postgrex.query!(conn, ~s/DROP ROLE IF EXISTS nocreaterole/, [])
+    end)
+
+    :ok
+  end
+
+  @tag :integration
+  @tag :postgres
+  test "returns :ok when all good" do
+    result =
+      start_supervised!({
+        Postgrex,
+        host: System.get_env("POSTGRES_HOST", "127.0.0.1"),
+        port: System.fetch_env!("POSTGRES_EXPOSED_PORT"),
+        username: System.fetch_env!("POSTGRES_USER"),
+        password: System.fetch_env!("POSTGRES_PASSWORD"),
+        host: "127.0.0.1",
+        database: "postgres"
+      })
+      |> MUT.check_privileges()
+
+    assert :ok == result
+  end
+
+  @tag :integration
+  @tag :postgres
+  test "returns error when user has no privilege to create databases" do
+    result =
+      start_supervised!(
+        {Postgrex,
+         host: System.get_env("POSTGRES_HOST", "127.0.0.1"),
+         port: System.fetch_env!("POSTGRES_EXPOSED_PORT"),
+         username: "nocreatedb",
+         password: "password",
+         host: "127.0.0.1",
+         database: "postgres"}
+      )
+      |> MUT.check_privileges()
+
+    assert {:error, "The user does not have the privilege to create databases"} ==
+             result
+  end
+
+  @tag :integration
+  @tag :postgres
+  test "returns error when user has no privilege to create roles" do
+    result =
+      start_supervised!(
+        {Postgrex,
+         host: System.get_env("POSTGRES_HOST", "127.0.0.1"),
+         port: System.fetch_env!("POSTGRES_EXPOSED_PORT"),
+         username: "nocreaterole",
+         password: "password",
+         host: "127.0.0.1",
+         database: "postgres"}
+      )
+      |> MUT.check_privileges()
+
+    assert {:error, reason} = result
+    assert reason =~ "The user does not have the privilege to create users"
+  end
+end


### PR DESCRIPTION
Before this PR, Kompost would query `pg_authid` to check whether the user defined in the `PostgresInstance` has the required privileges. However sometimes, although the user might have the required privileges, it might **not** have the privileges to query the `pg_authid` table. In these cases the check fails while it should succeed.

This PR changes the way Kompost checks for the required privileges:

* `CREATE ROLE` privilege: try to create a role within a transaction and roll it back at the end
* `CREATE DATABASE` privilege: use the `has_database_privilege` [System Information Function](https://www.postgresql.org/docs/8.0/functions-info.html)